### PR TITLE
feat: Add pink accent color theme

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,6 +36,13 @@
   --color-primary-dark: 109 40 217; /* violet-700 */
 }
 
+/* New Pink theme */
+:root.theme-pink {
+  --color-primary: 236 72 153; /* pink-500 */
+  --color-primary-light: 253 242 248; /* pink-50 */
+  --color-primary-dark: 190 24 93; /* pink-700 */
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,7 +42,7 @@ export default function RootLayout({
                   root.classList.add(resolvedMode === 'dark' ? 'dark' : 'light');
                   root.style.colorScheme = resolvedMode;
 
-                  root.classList.remove('theme-blue', 'theme-green', 'theme-rose', 'theme-amber', 'theme-violet');
+                  root.classList.remove('theme-blue', 'theme-green', 'theme-rose', 'theme-amber', 'theme-violet', 'theme-pink');
                   if (accentColor !== 'blue') {
                     root.classList.add('theme-' + accentColor);
                   }

--- a/src/components/color-theme-selector.tsx
+++ b/src/components/color-theme-selector.tsx
@@ -8,6 +8,7 @@ const colors = [
   { name: 'rose', label: 'Rose', class: 'bg-rose-500' },
   { name: 'amber', label: 'Amber', class: 'bg-amber-500' },
   { name: 'violet', label: 'Violet', class: 'bg-violet-500' },
+  { name: 'pink', label: 'Pink', class: 'bg-pink-500' },
 ] as const;
 
 export function ColorThemeSelector() {

--- a/src/contexts/theme-context.tsx
+++ b/src/contexts/theme-context.tsx
@@ -3,7 +3,7 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
 
 type ThemeMode = 'light' | 'dark' | 'system';
-type AccentColor = 'blue' | 'green' | 'rose' | 'amber' | 'violet';
+type AccentColor = 'blue' | 'green' | 'rose' | 'amber' | 'violet' | 'pink';
 
 interface ThemeContextType {
   mode: ThemeMode;
@@ -77,7 +77,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     const root = document.documentElement;
 
     // Remove all theme classes
-    root.classList.remove('theme-blue', 'theme-green', 'theme-rose', 'theme-amber', 'theme-violet');
+    root.classList.remove('theme-blue', 'theme-green', 'theme-rose', 'theme-amber', 'theme-violet', 'theme-pink');
 
     // Add the selected theme class (skip for blue as it's the default)
     if (accentColor !== 'blue') {


### PR DESCRIPTION
## Summary
- Adds a new pink accent color option to the theme selector
- Includes pink-500, pink-50, and pink-700 color variants
- Updates all theme-related components to support the new color

## Changes
- Added pink theme CSS variables in `globals.css`
- Updated `AccentColor` type to include 'pink'
- Added pink color option to theme selector component
- Updated theme class management in layout and theme context

## Test plan
- [x] Pink theme applies correctly in light mode
- [x] Pink theme applies correctly in dark mode
- [x] Theme persists across page reloads
- [x] Color selector UI includes the new pink option